### PR TITLE
Semantic?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ async fn handle_request(text: String) -> Result<Response> {
         .map_err(|_| worker::Error::BadEncoding)
         .unwrap();
 
-    let img = generate_image(&text).map_err(|_| worker::Error::BadEncoding)?;
+    let img = generate_image(&text).expect("image created");
 
     let mut headers = Headers::new();
     headers.set("content-type", "image/png")?;
@@ -51,7 +51,7 @@ fn generate_image(text: &str) -> Result<Vec<u8>> {
         justify_content: style::JustifyContent::Center,
         ..style::WindowStyle::default()
     })
-    .map_err(|_| worker::Error::BadEncoding)?;
+    .expect("intialize writer");
 
     let font = Vec::from(include_bytes!("../assets/SKRAPPA.ttf") as &[u8]);
 
@@ -69,13 +69,11 @@ fn generate_image(text: &str) -> Result<Vec<u8>> {
             },
             Some(font.clone()),
         )
-        .map_err(|_| worker::Error::BadEncoding)?;
+        .expect("set text");
 
-    writer.paint().map_err(|_| worker::Error::BadEncoding)?;
+    writer.paint().expect("paint img");
 
-    let img = writer
-        .encode(ImageOutputFormat::Png)
-        .map_err(|_| worker::Error::BadEncoding)?;
+    let img = writer.encode(ImageOutputFormat::Png).expect("encode png");
 
     Ok(img)
 }


### PR DESCRIPTION
This seems like a more correct way to handle errors. It seems like the BadEncoding error was being misused, since it was not describing an error related to encoding. I put in expect instead bc it was simple and seems easy to debug which is appealing bc I don;t have a good understanding yet.